### PR TITLE
Get rid of unnecessary  vertical scrollbar on desktop

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@ html {
 
 h1 {
 	margin: 0;
-	font-size: 15vw;
+	font-size: 20vmin;
 	letter-spacing: -0.2rem;
 	position: absolute;
 	top: 0;


### PR DESCRIPTION
The example creates unnecessary vertical scrollbar in landscape mode, i.e. when viewport width is more than viewport height.

Using unit `vmin` keeps text big without creating scrollbars.